### PR TITLE
Stop returning entire index when search string is empty.

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -9,7 +9,9 @@ $("#search").keyup(function(){
   if (params.indexOf('q=') == -1) {
     params += 'q=ussr';
   }
-  search(params.replace(/(q=)[^\&]+/, '$1' + $('#search').val()));
+  if ($('#search').val() != '') {
+    search(params.replace(/(q=)[^\&]+/, '$1' + $('#search').val()));
+  }
 });
 
 
@@ -21,7 +23,9 @@ $(document).ready(function() {
                               value:context[prop]});
     return ret;
   });
-  search(window.location.search.substring(1));
+  if ($('#search').val() != '') {
+    search(window.location.search.substring(1));
+  }
 });
 
 


### PR DESCRIPTION
For large indexes this can be slow; searching '*' still works though.

It is also annoying when backspacing and typing in a new search string. The slower empty search will eventually clobber the most current actual search.
