### PR TITLE
Stop returning entire index when search string is empty.

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -23,8 +23,9 @@ $(document).ready(function() {
                               value:context[prop]});
     return ret;
   });
-  if ($('#search').val() != '') {
-    search(window.location.search.substring(1));
+  var urlParams = window.location.search.substring(1);
+  if (urlParams != '') {
+    search(urlParams);
   }
 });
 


### PR DESCRIPTION
If the search string is empty, don't perform a search as it can be slow for a large index.

When backspacing a search, the empty search can clobber the most current non-empty search some time later. A search on .ready() is only performed if there are URL parameters.
