### PR TITLE
[docs] Update usage of searchFields search parameter in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Usage:
 
 Search on specified fields. Ignore text that exists in other fields.
 
-    searchFields=<comma seperated lists of fields to search in>
+    searchFields[]=<field to search in>
     
 [http://localhost:3000/search?q=plans&searchFields[]=body](http://localhost:3000/search?q=plans&searchFields[]=body)
 


### PR DESCRIPTION
The searchFields query parameter is no longer a comma separated list (like the facets), but rather an array (like filter & weight).

It's just a small doc change that caught me while I was writing a client.
