### PR TITLE
Update norch for changes in search-index

### DIFF
--- a/norch.js
+++ b/norch.js
@@ -52,9 +52,9 @@ function getQuery(req) {
     q['offset'] = offsetDefault;
   }
   if (req.query['pagesize']) {
-    q['pagesize'] = req.query['pagesize'];
+    q['pageSize'] = req.query['pagesize'];
   } else {
-    q['pagesize'] = pagesizeDefault;
+    q['pageSize'] = pagesizeDefault;
   }
   if (req.query['facets']) {
     q['facets'] = req.query['facets'].toLowerCase().split(',');


### PR DESCRIPTION
The change of `pagesize` to `pageSize` in fergiemcdowall/search-index@b1ae7bcb74c5a8eb3e686f4fd437ab9c98691398 breaks the server. No hits are returned (because `pageSize` is set to 0 automatically if not present)

**Merge only after that change has been pushed to npm!**
