### PR TITLE
More tolerant multiple words queries

### DIFF
--- a/lib/forage.js
+++ b/lib/forage.js
@@ -92,11 +92,11 @@ function getQuery(req) {
     if( Object.prototype.toString.call(req.query['q']) === '[object Object]' ) {
       var queryObject = req.query['q'];
       for (var k in queryObject) {
-        q['query'][k] = queryObject[k].toLowerCase().split(' ');
+        q['query'][k] = queryObject[k].toLowerCase().split(/\s+/);
       }
     }
     else {
-      q['query']['*'] = req.query['q'].toLowerCase().split(' ');
+      q['query']['*'] = req.query['q'].toLowerCase().split(/\s+/);
     }
   }
   if (req.query['fieldedQuery']) {


### PR DESCRIPTION
Previous version of query accepted just one whitespace. This corrects it and make it more tolerant.
