### PR TITLE
Wrapped call to search index in try - catch to enable a more graceful fa...

### DIFF
--- a/lib/norch.js
+++ b/lib/norch.js
@@ -37,10 +37,15 @@ app.post('/indexer', function(req, res) {
   }
   if (req.files.document) {
     fs.readFile(req.files.document.path, {'encoding': 'utf8'}, function(err, batch) {
-      if(err) return res.send(500, 'Error reading document');
-      si.add(JSON.parse(batch), req.files.document.name, filters, function(msg) {
-        res.send(msg);
-      });
+      if(err) return res.status(500).send('Error reading document');
+
+      try {
+          si.add(JSON.parse(batch), req.files.document.name, filters, function (msg) {
+              res.send(msg);
+          });
+      } catch (e) {
+          res.status(500).send("Failed to index document.\n")
+      }
     });
   }
   else {
@@ -49,7 +54,6 @@ app.post('/indexer', function(req, res) {
     });
   }
 });
-
 
 
 if (process.argv.indexOf('-h') == -1) {
@@ -210,5 +214,3 @@ app.get('/search', function(req, res) {
     res.send(msg);
   });
 });
-
-


### PR DESCRIPTION
...il when indexing fails. Replaced the deprecated calls to res.send(yyy, message) to res.status(yyy).send(message)
