### PR TITLE
Add command-line option for CORS

### DIFF
--- a/lib/norch.js
+++ b/lib/norch.js
@@ -4,14 +4,9 @@ var Norch = module.exports = function(options) {
     return new Norch(options);
   }
 
-  //CORS middleware
-  this.allowCrossDomain = function(req, res, next) {
-    res.header('Access-Control-Allow-Origin', 'http://localhost:8000');
-    res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
-    res.header('Access-Control-Allow-Headers', 'Content-Type');
-    next();
-  }
-
+  var listToArray = function(val) {
+      return [].concat(val.split(','));
+  };
 
   this.bodyParser = require('body-parser');
   this.colors = require('colors');
@@ -26,6 +21,7 @@ var Norch = module.exports = function(options) {
     .option('-i, --indexPath <indexPath>', 'specify the name of the index directory, defaults to norch-index', String, options.indexPath || 'norch-index')
     .option('-l, --logLevel <logLevel>', 'specify the loglevel- silly | debug | verbose | info | warn | error', String, options.logLevel || 'info')
     .option('-s, --logSilent <logSilent>', 'silent mode', String, options.logSilent || 'false')
+    .option('-c, --cors <items>', 'comma-delimited list of Access-Control-Allow-Origin addresses in the form of "http(s)://hostname:port" (or "*")', listToArray, options.cors || '')
     .parse(process.argv);
 
   var SearchIndex = require('search-index');
@@ -40,9 +36,25 @@ var Norch = module.exports = function(options) {
   //to save uploaded files do "app.use(multer({ dest: './tmp/'}));"
   this.app.use(this.multer());
   this.app.use(this.bodyParser.json());
-  this.app.use(this.allowCrossDomain);
 
-  
+  if (this.program.cors && this.program.cors.length >= 1){
+    this.allowCrossDomain = function(req, res, next) {
+        // NOTE: correct way would be to only emit if we match on req.host
+        // SEE: http://www.w3.org/TR/cors/#access-control-allow-origin-response-header
+        // This would greatly simplify the code because we could use the object overload of
+        // res.header({ Access-Control-Allow-Origin: origin, Access-Control-Allow-Methods: 'GET..', ...});
+        // Drawback would be a slightly more complicated implementation when passing "*"
+        this.program.cors.forEach(function(origin) {
+            res.header('Access-Control-Allow-Origin', origin);
+        });
+        res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
+        res.header('Access-Control-Allow-Headers', 'Content-Type');
+        return next();
+    }.bind(this);
+
+    this.app.use(this.allowCrossDomain);
+  }
+
   //curl --form document=@testdata.json http://localhost:3030/indexer
   //--form facetOn=topics
   this.app.post('/indexer', function (req, res) {
@@ -120,7 +132,7 @@ var Norch = module.exports = function(options) {
                   + that.program.hostname + ' on port '
                   + that.program.port);
       console.log();
-    });  
+    });
   }
 
 


### PR DESCRIPTION
* Adds command-line option (-c, --cors)
* Only adds CORS middleware if user passes one or more addresses

If you'd like to keep "http://localhost:8000" as a default, it could be done in either:
* The default value within the command-line parser, or
* The defaults passed in via the ./bin/norch script