### PR TITLE
Fix delete endpoint to parse body like add

### DIFF
--- a/lib/norch.js
+++ b/lib/norch.js
@@ -102,7 +102,7 @@ var startServer = function (siOptions, callback) {
   }))
 
   norch.post('/add', restify.bodyParser(), routes.add)
-  norch.post('/delete', routes.del)
+  norch.post('/delete', restify.bodyParser(), routes.del)
   norch.post('/replicate', routes.replicate)
 
   return callback(null, norch)


### PR DESCRIPTION
Right now the `/delete` endpoint doesn't seem to work, this brings it up to parity with the `/add` endpoint.